### PR TITLE
Bug/ch331/fix bugs where color palette is messed up for some cropped images

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -120,7 +120,7 @@ class Engine(BaseEngine):
         # Indexed color modes (such as 1 and P) will be forced to use a
         # nearest neighbor resampling algorithm. So we convert them to
         # RGBA mode before resizing to avoid nasty scaling artifacts.
-        original_mode = self.image.mode
+        # original_mode = self.image.mode # Disabling this. See below... (Roger 1/19/18)
         if self.image.mode in ['1', 'P']:
             logger.debug('converting image from 8-bit/1-bit palette to 32-bit RGBA for resize')
             self.image = self.image.convert('RGBA')
@@ -128,7 +128,7 @@ class Engine(BaseEngine):
         resample = self.get_resize_filter()
         self.image = self.image.resize((int(width), int(height)), resample)
 
-        # (Roger 1/19/2018) Disabling this! Converting 32-bit back to 8 or 1-bit causes banding and other artifacts.
+        # (Roger 1/19/18) Disabling this! Converting 32-bit back to 8 or 1-bit causes banding and other artifacts.
         # # 1 and P mode images will be much smaller if converted back to
         # # their original mode. So let's do that after resizing. Get $$.
         # if original_mode != self.image.mode:

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -128,10 +128,11 @@ class Engine(BaseEngine):
         resample = self.get_resize_filter()
         self.image = self.image.resize((int(width), int(height)), resample)
 
-        # 1 and P mode images will be much smaller if converted back to
-        # their original mode. So let's do that after resizing. Get $$.
-        if original_mode != self.image.mode:
-            self.image = self.image.convert(original_mode)
+        # (Roger 1/19/2018) Disabling this! Converting 32-bit back to 8 or 1-bit causes banding and other artifacts.
+        # # 1 and P mode images will be much smaller if converted back to
+        # # their original mode. So let's do that after resizing. Get $$.
+        # if original_mode != self.image.mode:
+        #     self.image = self.image.convert(original_mode)
 
     def crop(self, left, top, right, bottom):
         self.image = self.image.crop((


### PR DESCRIPTION
This PR fixes a bug in Thumbor. Some of our source images are PNGs with mode 'P'. For these images, Thumbor converts from P to RGBA during resizing, and then converts back to P. However, this conversion from RGBA back to P causes color-banding and other artifacts, e.g. http://images.adrise.tv/4yYx2LrkRcXxx2MCOuR03ItDOmc=/214x306/smart/img.adrise.tv/46e01a0b-e372-4774-a13a-62b8ff471d89.png.

I've commented out this logic from Thumbor's code. It's not necessary for us, since we return all images from Thumbor as jpegs anyways. (Our optimizer converts any P images back to RGB, since P mode can't be saved as jpeg. See https://github.com/adRise/romantico/blob/master/optimizer/basic.py#L25).

I've tested out these changes a few images, and this works fine. In fact, the resulting images are smaller than with our current code. I'll keep testing more images. Also, I'm still trying to figure out how we'll deploy this out; may need to flush CDN cache. Meanwhile, please CR, @wanghaofei90.